### PR TITLE
fix: bump dfj-container feature version

### DIFF
--- a/src/dfj-container/devcontainer-feature.json
+++ b/src/dfj-container/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "DFJ Container",
   "id": "dfj-container",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "containerEnv": {
     "_CONTAINER_USER": "vscode"
   },


### PR DESCRIPTION
Bumps the dfj-container feature to 0.9.10 so the desktop-lite removal can be published as a new immutable feature version.