### PR TITLE
fix: install fish from apt

### DIFF
--- a/src/dfj-container/devcontainer-feature.json
+++ b/src/dfj-container/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "DFJ Container",
   "id": "dfj-container",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "containerEnv": {
     "_CONTAINER_USER": "vscode"
   },
@@ -16,7 +16,6 @@
     "ghcr.io/devcontainers/features/ruby:1":{},
     "ghcr.io/devcontainers/features/node:1":{},
     "ghcr.io/devcontainers-community/npm-features/typescript:1":{},
-    "ghcr.io/meaningful-ooo/devcontainer-features/fish:1":{},
     "ghcr.io/devcontainers/features/github-cli:1":{},
     "ghcr.io/devcontainers/features/copilot-cli:1":{}
   },

--- a/src/dfj-container/install.sh
+++ b/src/dfj-container/install.sh
@@ -21,6 +21,7 @@ sudo apt-get update
 sudo apt-get install -y \
   jq \
   build-essential \
+  fish \
   unzip \
   luarocks \
   ncurses-bin \


### PR DESCRIPTION
Removes the PPA-backed fish devcontainer feature, installs fish from Ubuntu packages in dfj-container, and bumps the feature to 0.9.12 for publishing.